### PR TITLE
Update gitlab.yml

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -32,5 +32,5 @@ jobs:
           {
             "PROJECT": "k-min-sum-radii",
             "GIT_HASH": "${{ github.event.pull_request.head.sha || github.sha }}",
-            "PIPELINES": "ubuntu,debian,arch,ventura,monterey,windows"
+            "PIPELINES": "ubuntu,debian,ventura,windows"
           }


### PR DESCRIPTION
Removed monterey as the runner is not available anymore. Arch shouldn't also run per default, only on request